### PR TITLE
update node version in README to working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm is distributed with Node.js which means that when you download Node.js, you 
 ### Installing
 
 #### Node.js / npm
-- Get Node.js: https://nodejs.org/en/ (v8.11.1 LTS)
+- Get Node.js: https://nodejs.org/en/ (v10.19.1.0+)
 
 - If you use [Homebrew](https://brew.sh/) you can install node by doing:
 ```


### PR DESCRIPTION
As pointed in the issue #27: Some of the recent code usues newer node features and therefore updating the supported node version to 10.19.0 in README.

As stated in the issue, AJV does work with node v8.11.1. Therefore we should be able to use it, but in the lack of user requirement we will not spend time on this now. 