### PR TITLE
JSON Schema draft 2020 compatibility addition

### DIFF
--- a/examples/both/test-06SchemaDraft-invalid.json
+++ b/examples/both/test-06SchemaDraft-invalid.json
@@ -1,0 +1,17 @@
+{
+    "schema": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "$id": "http://example.com/schema/test06-const",
+        "type": "object",
+        "properties": {
+        "foo": {
+            "const": "red"
+        }
+        },
+        "required": ["foo"]
+    },
+    "data": {
+        "foo": "blue"
+    }
+}
+  

--- a/examples/both/test-06SchemaDraft-valid.json
+++ b/examples/both/test-06SchemaDraft-valid.json
@@ -1,0 +1,17 @@
+{
+    "schema": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "$id": "http://example.com/schema/test06-const",
+        "type": "object",
+        "properties": {
+        "foo": {
+            "const": "red"
+        }
+        },
+        "required": ["foo"]
+    },
+    "data": {
+        "foo": "red"
+    }
+}
+  

--- a/examples/both/test-07SchemaDraft-invalid.json
+++ b/examples/both/test-07SchemaDraft-invalid.json
@@ -1,0 +1,20 @@
+{
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "http://example.com/schema/test07-ifthen",
+      "type": "object",
+      "properties": {
+        "foo": { "type": "string" }
+      },
+      "if": {
+        "required": ["foo"]
+      },
+      "then": {
+        "required": ["bar"]
+      }
+    },
+    "data": {
+      "foo": "hello"
+    }
+}
+  

--- a/examples/both/test-07SchemaDraft-valid.json
+++ b/examples/both/test-07SchemaDraft-valid.json
@@ -1,0 +1,21 @@
+{
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "http://example.com/schema/test07-ifthen",
+      "type": "object",
+      "properties": {
+        "foo": { "type": "string" }
+      },
+      "if": {
+        "required": ["foo"]
+      },
+      "then": {
+        "required": ["bar"]
+      }
+    },
+    "data": {
+      "foo": "hello",
+      "bar": 123
+    }
+}
+  

--- a/examples/both/test-2019SchemaDraft-invalid.json
+++ b/examples/both/test-2019SchemaDraft-invalid.json
@@ -1,0 +1,14 @@
+{
+    "schema": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$id": "http://example.com/schema/test2019",
+        "type": "object",
+        "required": ["foo"],
+        "properties": {
+            "foo": { "type": "string" }
+        }
+    },
+    "data": {
+        "foo": 123
+    }
+}

--- a/examples/both/test-2019SchemaDraft-valid.json
+++ b/examples/both/test-2019SchemaDraft-valid.json
@@ -1,0 +1,14 @@
+{
+    "schema": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$id": "http://example.com/schema/test2019",
+        "type": "object",
+        "required": ["foo"],
+        "properties": {
+            "foo": { "type": "string" }
+        }
+    },
+    "data": {
+        "foo": "foo"
+    }
+}

--- a/examples/both/test-2020SchemaDraft-invalid.json
+++ b/examples/both/test-2020SchemaDraft-invalid.json
@@ -1,0 +1,14 @@
+{
+    "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "http://example.com/schema/test2020",
+        "type": "object",
+        "required": ["foo"],
+        "properties": {
+            "foo": { "type": "string" }
+        }
+    },
+    "data": {
+        "foo": 123
+    }
+}

--- a/examples/both/test-2020SchemaDraft-valid.json
+++ b/examples/both/test-2020SchemaDraft-valid.json
@@ -1,0 +1,14 @@
+{
+    "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "http://example.com/schema/test2020",
+        "type": "object",
+        "required": ["foo"],
+        "properties": {
+            "foo": { "type": "string" }
+        }
+    },
+    "data": {
+        "foo": "foo"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "EMBL-EBI-AIT, fpenim, ke4, haseeb-gh, theisuru",
   "license": "Apache-2.0",
   "dependencies": {
-    "ajv": "8.12.0",
+    "ajv": "^8.12.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "2.1.1",
     "axios": "^1.3.2",

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -30,11 +30,6 @@ class BioValidator {
 
     // wrapper around _validate to process output
     validate(inputSchema, inputObject) {
-        if (inputSchema["$schema"] && inputSchema["$schema"].includes("2020-12")) {
-            let appError = new AppError("JSON Schema draft-2020-12 is not supported currently");
-            return new Promise((resolve, reject) => reject(appError));
-        }
-
         return new Promise((resolve, reject) => {
             this._validate(inputSchema, inputObject)
                 .then((validationResult) => {

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -70,9 +70,9 @@ class BioValidator {
     // We populate all schemas/defs with $async as a workaround to avoid users manually entering $async in schemas.
     _insertAsyncToSchemasAndDefs(inputSchema) {
         // If it's the known meta-schema ID, skip
-        if (typeof inputSchema.$id === "string") {
-            if (inputSchema.$id.startsWith("http://json-schema.org/draft")
-                || inputSchema.$id.startsWith("https://json-schema.org/draft")) {
+        if (typeof inputSchema.$schema === "string") {
+            if (inputSchema.$schema.startsWith("http://json-schema.org/draft")
+                || inputSchema.$schema.startsWith("https://json-schema.org/draft")) {
                 return;
             }
         }

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -70,9 +70,11 @@ class BioValidator {
     // We populate all schemas/defs with $async as a workaround to avoid users manually entering $async in schemas.
     _insertAsyncToSchemasAndDefs(inputSchema) {
         // If it's the known meta-schema ID, skip
-        if (inputSchema.$id.startsWith("http://json-schema.org/draft")
-            || inputSchema.$id.startsWith("https://json-schema.org/draft")) {
-            return;
+        if (typeof inputSchema.$id === "string") {
+            if (inputSchema.$id.startsWith("http://json-schema.org/draft")
+                || inputSchema.$id.startsWith("https://json-schema.org/draft")) {
+                return;
+            }
         }
 
         inputSchema["$async"] = true;

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -1,6 +1,4 @@
-const Ajv = require("ajv")
-const Ajv2019 = require("ajv/dist/2019").default;
-const Ajv2020 = require("ajv/dist/2020")
+const Ajv = require("ajv").default;
 const addFormats = require("ajv-formats");
 const axios = require('axios');
 const AppError = require("../model/application-error");
@@ -144,9 +142,14 @@ class BioValidator {
     }
 
     _getAjvInstance(localSchemaPath) {
-        const ajvInstance = new Ajv2019({allErrors: true, strict: false, loadSchema: this._resolveReference()});
-        // const ajvInstance = new Ajv2020({allErrors: true, strict: false, loadSchema: this._resolveReference()});
-        const draft7MetaSchema = require("ajv/dist/refs/json-schema-draft-07.json")
+        const ajvInstance = new Ajv({
+            allErrors: true,
+            strict: false,
+            loadSchema: this._resolveReference(),
+            $data: true,   // for older draft usage
+            next: true     // helps with 2019 features
+        });
+        
         ajvInstance.addMetaSchema(draft7MetaSchema)
         addFormats(ajvInstance);
         require("ajv-errors")(ajvInstance)

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -220,7 +220,7 @@ class BioValidator {
          // Ensure 'this' context is correct when loadSchema is called by Ajv
          const self = this;
          return (uri) => {
-            logger.debug(`AJV requesting schema load for URI: ${uri}`);
+            logger.debug(`AJV requesting schema load (either from network or local cache) for URI: ${uri}`);
              // skip if it's an official meta-schema
              if (
                  uri.startsWith("http://json-schema.org/draft") ||
@@ -233,11 +233,10 @@ class BioValidator {
                  logger.debug("Returning referenced schema from reference cache: " + uri);
                  return Promise.resolve(self.referencedSchemaCache.get(uri));
              } else {
-                 logger.debug(`Attempting to fetch schema from network/local: ${uri}`);
+                 logger.debug(`Fetching referenced schema from network: ${uri}`);
                  return new Promise((resolve, reject) => {
                      axios({method: "GET", url: uri, responseType: 'json'})
                          .then(resp => {
-                             logger.debug(`Successfully fetched schema via network: ${uri}`);
                              const loadedSchema = resp.data;
                              self._insertAsyncToSchemasAndDefs(loadedSchema);
                              self.referencedSchemaCache.set(uri, loadedSchema);

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -29,7 +29,7 @@ class BioValidator {
     // wrapper around _validate to process output
     validate(inputSchema, inputObject) {
         const sid = inputSchema["$id"] || "(no $id)";
-        logger.debug(`BioValidator.validate() called for schema $id: ${sid}`);
+        logger.debug(`BioValidator.validate() called for initial schema $id: ${sid}`);
 
         return new Promise((resolve, reject) => {
             this._validate(inputSchema, inputObject)
@@ -42,11 +42,12 @@ class BioValidator {
                     }
                 })
                 .catch((error) => {
+                    logger.error(`BioValidator.validate() caught error processing schema $id: ${sid}. Error: ${error.message || JSON.stringify(error)}`);
                     if (error.errors) {
-                        logger.error("An error occurred while running the validation: " + JSON.stringify(error));
+                        logger.error("AJV validation errors encountered: " + JSON.stringify(error.errors));
                         reject(new AppError(error.errors));
                     } else {
-                        logger.error("An error occurred while running the validation: " + JSON.stringify(error));
+                        logger.error("Non-AJV error during validation: " + JSON.stringify(error));
                         reject(error);
                     }
                 });
@@ -70,6 +71,7 @@ class BioValidator {
     // AJV requires $async keyword in schemas if they use any of async custom defined keywords.
     // We populate all schemas/defs with $async as a workaround to avoid users manually entering $async in schemas.
     _insertAsyncToSchemasAndDefs(inputSchema) {
+        const schemaIdForLog = inputSchema.$id || "[no $id at root]"; // Use for logging
         // If it's the known meta-schema ID, skip adding $async
         if (
             typeof inputSchema.$id === "string" &&
@@ -78,79 +80,90 @@ class BioValidator {
                 inputSchema.$id.startsWith("https://json-schema.org/draft")
             )
         ) {
-            logger.debug(`Skipping $async injection for official meta-schema $id: ${inputSchema.$id || "[no $id at root]"}`);
+            logger.debug(`Skipping $async injection for official meta-schema $id: ${schemaIdForLog}`);
             return;
         }
 
         if (!inputSchema.hasOwnProperty("$async")) {
             inputSchema["$async"] = true;
-            logger.debug(`Auto-injected "$async": true at root for schema $id: ${inputSchema.$id || "[no $id at root]"}`);
+            logger.debug(`Auto-injected "$async": true at root for schema $id: ${schemaIdForLog}`);
         } else if (inputSchema.$async === true) {
-            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' for schema $id: ${inputSchema.$id || "[no $id at root]"}`);
+            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' for schema $id: ${schemaIdForLog}`);
         } else if (inputSchema.$async === false) {
-            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' ('$async' injection will be skipped for definitions) for schema $id: ${inputSchema.$id || "[no $id at root]"}`);
-            return;
+            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' ('$async' injection will be skipped for definitions) for schema $id: ${schemaIdForLog}`);
+            return; // Don't inject if explicitly false
         }
 
+        // Also inject into definitions/$defs if root $async is true (or missing)
         if (inputSchema.hasOwnProperty("definitions")) {
             let defs = Object.keys(inputSchema.definitions);
             for (let x = 0; x < defs.length; x++) {
-                inputSchema.definitions[defs[x]]["$async"] = true;
+                if (typeof inputSchema.definitions[defs[x]] === 'object' && inputSchema.definitions[defs[x]] !== null) {
+                     inputSchema.definitions[defs[x]]["$async"] = true;
+                }
             }
         } else if (inputSchema.hasOwnProperty("$defs")) { // support draft‑2019/2020 keyword ($defs)
-            for (const k of Object.keys(inputSchema.$defs)) {
-                inputSchema.$defs[k]["$async"] = true;
-            }
+             for (const k of Object.keys(inputSchema.$defs)) {
+                if (typeof inputSchema.$defs[k] === 'object' && inputSchema.$defs[k] !== null) {
+                    inputSchema.$defs[k]["$async"] = true;
+                }
+             }
         }
     }
 
     _validate(inputSchema, inputObject) {
+        const schemaIdForLog = inputSchema.$id || "[no $id in schema]"; // Use for logging
         this._insertAsyncToSchemasAndDefs(inputSchema);
         // The following is useful for when doing a deep-debugging of schema issues, but too verbose otherwise
         // logger.debug("Final schema after injection:\n" + JSON.stringify(inputSchema, null, 2));
 
         return new Promise((resolve, reject) => {
+            logger.debug(`Attempting to get compiled validation function for schema $id: ${schemaIdForLog}'}`);
             const compiledSchemaPromise = this.getValidationFunction(inputSchema);
 
             compiledSchemaPromise.then((validate) => {
+                logger.info(`Successfully obtained compiled function for schema $id: ${schemaIdForLog}'}. Now validating data.`);
                 Promise.resolve(validate(inputObject))
                     .then((data) => {
                         if (validate.errors) {
+                            logger.info(`Validation finished with errors for schema $id: ${schemaIdForLog}'}.`);
                             resolve(validate.errors);
                         } else {
+                           logger.info(`Validation finished successfully for schema $id: ${schemaIdForLog}'}.`);
                             resolve([]);
                         }
                     })
                     .catch((err) => {
                         if (!(err instanceof Ajv.ValidationError)) {
-                            logger.error("An error occurred while running the validation. " + err);
-                            reject(new AppError("An error occurred while running the validation. " + err));
+                            logger.error("An unexpected error occurred during data validation execution. " + (err.message || err));
+                            reject(new AppError("An error occurred while running the validation. " + (err.message || err)));
                         } else {
-                            logger.info("Validation failed with errors: " + this.ajvInstance.errorsText(err.errors, {dataVar: inputObject.alias}));
+                            logger.info("Validation failed with AJV ValidationError: " + this.ajvInstance.errorsText(err.errors, {dataVar: inputObject.alias}));
                             resolve(err.errors);
                         }
                     });
-                }).catch(err => {
-                    if (err instanceof Ajv.MissingRefError) {
-                        logger.error(
-                            `Failed to compile - missing $ref '${err.missingRef}' ` +
-                            `in schema '${err.missingSchema || inputSchema.$id || "(root)"}'`
-                        );
-                    } else if (err instanceof AppError) {
-                        logger.error(err.error || err.message || JSON.stringify(err));
-                    } else if (err.errors && err.errors.length) {
-                        logger.error(
-                            "Schema compile errors:\n" +
-                            err.errors
-                               .map(e => `  ✖ ${e.message} @ ${e.schemaPath}`)
-                               .join("\n")
-                        );
-                    } else {
-                        logger.error("Unexpected compile failure:\t" + (err.stack || err));
-                    }
-                    reject(new AppError("Failed to compile schema. See server log for details."));
-                });
-            });
+             }).catch(err => {
+                 logger.error(`Failed to compile/get validation function for schema $id: ${schemaIdForLog}. Error: ${err.message || JSON.stringify(err)}`);
+                 if (err instanceof Ajv.MissingRefError) {
+                     logger.error(
+                         `AJV MissingRefError (Failed to compile - missing $ref)': ${err.missingRef}'. ` +
+                         `Base URI/Schema where error occurred: '${err.missingSchema || inputSchema.$id || "(root)"}'`
+                     );
+                 } else if (err instanceof AppError) {
+                     logger.error(`AppError during compile: ${err.error || err.message || JSON.stringify(err)}`);
+                 } else if (err.errors && err.errors.length) {
+                     logger.error(
+                         "AJV schema compilation errors:\n" +
+                         err.errors
+                            .map(e => ` ${e.message || JSON.stringify(e)} @ ${e.schemaPath || 'unknown path'}`)
+                            .join("\n")
+                     );
+                 } else {
+                     logger.error("Unexpected compile failure type: " + (err.stack || err));
+                 }
+                 reject(new AppError("Failed to compile schema. See server log for details."));
+             });
+         });
     }
 
     convertToValidationErrors(ajvErrorObjects) {
@@ -171,16 +184,17 @@ class BioValidator {
     getValidationFunction(inputSchema) {
         const schemaId = inputSchema['$id'];
         if (schemaId && this.validatorCache.has(schemaId)) {
-            logger.info("Returning compiled schema from cache, $id: " + schemaId);
+            logger.info("Returning compiled schema from validator cache, $id: " + schemaId);
             return Promise.resolve(this.validatorCache.get(schemaId));
         }
 
+        logger.debug(`Compiling schema $id: ${schemaId || '(no $id)'}. This will trigger loading of external references.`);
         const compiledSchemaPromise = this.ajvInstance.compileAsync(inputSchema);
         if (schemaId) {
-            logger.info("Saving compiled schema in cache, $id: " + schemaId);
+            logger.info("Saving compiled schema in validator cache, $id: " + schemaId);
             this.validatorCache.set(schemaId, compiledSchemaPromise);
         } else {
-            logger.warn("Compiling schema with empty schema $id. Schema will not be cached.");
+            logger.warn("Compiling schema with empty schema $id. Schema will not be cached in validator cache.");
         }
         return Promise.resolve(compiledSchemaPromise);
     }
@@ -188,12 +202,11 @@ class BioValidator {
     _getAjvInstance(localSchemaPath) {
         const ajvInstance = new Ajv({
             allErrors: true,
-            strict: false,
+            strict: false, // Setting strict: false might hide some issues but is often needed for complex schemas. If needed, set it to 'log' or true for debugging.
             loadSchema: this._resolveReference(),
             $data: true,   // for older draft usage
-            next: true     // helps with 2019 features
         });
-        
+
         addFormats(ajvInstance);
         require("ajv-errors")(ajvInstance);
 
@@ -203,46 +216,49 @@ class BioValidator {
         return ajvInstance;
     }
 
-    _resolveReference() {
-        return (uri) => {
-            // skip if it's an official meta-schema
-            if (
-                uri.startsWith("http://json-schema.org/draft") ||
-                uri.startsWith("https://json-schema.org/draft")
-            ) {
-                logger.debug(`Skipping meta-schema fetch: ${uri}`);
-                return Promise.resolve({});
-            }
-            if (this.referencedSchemaCache.has(uri)) {
-                logger.info("Returning referenced schema from cache: " + uri);
-                return Promise.resolve(this.referencedSchemaCache.get(uri));
-            } else {
-                return new Promise((resolve, reject) => {
-                    axios({method: "GET", url: uri, responseType: 'json'})
-                        .then(resp => {
-                            logger.info("Returning referenced schema from network : " + uri);
-                            const loadedSchema = resp.data;
-                            this._insertAsyncToSchemasAndDefs(loadedSchema);
-                            this.referencedSchemaCache.set(uri, loadedSchema);
-                            resolve(loadedSchema);
-                        }).catch(err => {
+     _resolveReference() {
+         // Ensure 'this' context is correct when loadSchema is called by Ajv
+         const self = this;
+         return (uri) => {
+            logger.debug(`AJV requesting schema load for URI: ${uri}`);
+             // skip if it's an official meta-schema
+             if (
+                 uri.startsWith("http://json-schema.org/draft") ||
+                 uri.startsWith("https://json-schema.org/draft")
+             ) {
+                 logger.debug(`Skipping official meta-schema fetch: ${uri}`);
+                 return Promise.resolve({});
+             }
+             if (self.referencedSchemaCache.has(uri)) {
+                 logger.debug("Returning referenced schema from reference cache: " + uri);
+                 return Promise.resolve(self.referencedSchemaCache.get(uri));
+             } else {
+                 logger.debug(`Attempting to fetch schema from network/local: ${uri}`);
+                 return new Promise((resolve, reject) => {
+                     axios({method: "GET", url: uri, responseType: 'json'})
+                         .then(resp => {
+                             logger.debug(`Successfully fetched schema via network: ${uri}`);
+                             const loadedSchema = resp.data;
+                             self._insertAsyncToSchemasAndDefs(loadedSchema);
+                             self.referencedSchemaCache.set(uri, loadedSchema);
+                             resolve(loadedSchema);
+                         }).catch(err => {
                             // If Axios reached the server but got an HTTP error (e.g., 404, 500...), 
                             //      err.response exists, and we keep the numeric status
                             // If the request never left the host (e.g., bad domain), err.response is
-                            //      undefined (?), and we label it "nerwork/DNS"
-                            const status =
-                                err.response ? err.response.status : "network/DNS";
-                            logger.error(
-                                `Failed to fetch referenced schema (status: ${status}): ${uri}`
-                            );
-                            reject(
-                                new AppError(`Failed to resolve $ref (status: ${status}): ${uri}`)
-                            );
-                        });
-                });
-            }
-        };
-    }
+                            //      undefined (?), and we label it "network/DNS/file"
+                             const status = err.response ? err.response.status : "network/DNS/file";
+                             logger.error(
+                                 `Failed to fetch referenced schema URI: ${uri} (Status: ${status}). Error: ${err.message || err}`
+                             );
+                             reject(
+                                 new AppError(`Failed to resolve $ref via network/file (status: ${status}): ${uri}. Original error: ${err.message}`)
+                             );
+                         });
+                 });
+             }
+         };
+     }
 
     _addCustomKeywordValidators(ajvInstance) {
         customKeywordValidators.forEach(customKeywordValidator => {
@@ -254,14 +270,37 @@ class BioValidator {
 
     _preCompileLocalSchemas(ajv, localSchemaPath) {
         if (localSchemaPath) {
-            logger.info("Compiling local schema from: " + localSchemaPath);
-            let schemaFiles = getFiles(localSchemaPath);
-            for (let file of schemaFiles) {
-                let schema = readFile(file);
-                this._insertAsyncToSchemasAndDefs(schema);
-                ajv.getSchema(schema["$id"] || ajv.compile(schema)); // add to AJV cache if not already present
-                this.referencedSchemaCache.set(schema["$id"], schema);
-                logger.info("Adding compiled local schema to cache: " + schema["$id"]);
+            logger.info("Pre-compiling local schemas from: " + localSchemaPath);
+            try {
+                let schemaFiles = getFiles(localSchemaPath);
+                for (let file of schemaFiles) {
+                    try {
+                        let schema = readFile(file);
+                        const schemaId = schema["$id"]; // Get ID before potentially modifying schema
+                        if (!schemaId) {
+                           logger.warn(`Local schema file ${file} lacks a '$id'. It might not be correctly referenceable or cached.`);
+                           // Optionally assign a file-based ID: schema['$id'] = Path.resolve(file).toURI();
+                           // Or skip pre-compilation if ID is essential: continue;
+                        }
+                        this._insertAsyncToSchemasAndDefs(schema);
+                        // Add to AJV instance cache AND reference cache
+                        // Use addSchema instead of getSchema/compile to handle potential async refs within local files too
+                         if (schemaId && !ajv.getSchema(schemaId)) {
+                            ajv.addSchema(schema, schemaId); // Add schema to AJV instance
+                            this.referencedSchemaCache.set(schemaId, schema); // Also add to reference cache
+                            logger.info(`Added pre-compiled local schema to caches: ${schemaId}`);
+                         } else if (!schemaId) {
+                            // AJV might compile it later if referenced, but we can't easily cache/manage it without an ID
+                            logger.warn(`Skipping caching for schema ${file} due to missing $id.`);
+                         } else {
+                             logger.debug(`Schema ${schemaId} already known to AJV or in reference cache.`);
+                         }
+                    } catch(fileReadError) {
+                       logger.error(`Error reading or parsing local schema file ${file}: ${fileReadError.message}`);
+                    }
+                }
+            } catch (dirError) {
+               logger.error(`Error accessing local schema path ${localSchemaPath}: ${dirError.message}`);
             }
         }
     }

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -270,37 +270,14 @@ class BioValidator {
 
     _preCompileLocalSchemas(ajv, localSchemaPath) {
         if (localSchemaPath) {
-            logger.info("Pre-compiling local schemas from: " + localSchemaPath);
-            try {
-                let schemaFiles = getFiles(localSchemaPath);
-                for (let file of schemaFiles) {
-                    try {
-                        let schema = readFile(file);
-                        const schemaId = schema["$id"]; // Get ID before potentially modifying schema
-                        if (!schemaId) {
-                           logger.warn(`Local schema file ${file} lacks a '$id'. It might not be correctly referenceable or cached.`);
-                           // Optionally assign a file-based ID: schema['$id'] = Path.resolve(file).toURI();
-                           // Or skip pre-compilation if ID is essential: continue;
-                        }
-                        this._insertAsyncToSchemasAndDefs(schema);
-                        // Add to AJV instance cache AND reference cache
-                        // Use addSchema instead of getSchema/compile to handle potential async refs within local files too
-                         if (schemaId && !ajv.getSchema(schemaId)) {
-                            ajv.addSchema(schema, schemaId); // Add schema to AJV instance
-                            this.referencedSchemaCache.set(schemaId, schema); // Also add to reference cache
-                            logger.info(`Added pre-compiled local schema to caches: ${schemaId}`);
-                         } else if (!schemaId) {
-                            // AJV might compile it later if referenced, but we can't easily cache/manage it without an ID
-                            logger.warn(`Skipping caching for schema ${file} due to missing $id.`);
-                         } else {
-                             logger.debug(`Schema ${schemaId} already known to AJV or in reference cache.`);
-                         }
-                    } catch(fileReadError) {
-                       logger.error(`Error reading or parsing local schema file ${file}: ${fileReadError.message}`);
-                    }
-                }
-            } catch (dirError) {
-               logger.error(`Error accessing local schema path ${localSchemaPath}: ${dirError.message}`);
+            logger.info("Compiling local schema from: " + localSchemaPath);
+            let schemaFiles = getFiles(localSchemaPath);
+            for (let file of schemaFiles) {
+                let schema = readFile(file);
+                this._insertAsyncToSchemasAndDefs(schema);
+                ajv.getSchema(schema["$id"] || ajv.compile(schema)); // add to AJV cache if not already present
+                this.referencedSchemaCache.set(schema["$id"], schema);
+                logger.info("Adding compiled local schema to cache: " + schema["$id"]);
             }
         }
     }

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -28,28 +28,28 @@ class BioValidator {
 
     // wrapper around _validate to process output
     validate(inputSchema, inputObject) {
+        const sid = inputSchema["$id"] || "(no $id)";
+        logger.debug(`BioValidator.validate() called for schema $id: ${sid}`);
+
         return new Promise((resolve, reject) => {
             this._validate(inputSchema, inputObject)
                 .then((validationResult) => {
-                        if (validationResult.length === 0) {
-                            resolve([]);
-                        } else {
-                            let ajvErrors = [];
-                            validationResult.forEach(validationError => {
-                                ajvErrors.push(validationError);
-                            });
-                            resolve(this.convertToValidationErrors(ajvErrors));
-                        }
+                    if (validationResult.length === 0) {
+                        resolve([]);
+                    } else {
+                        const ajvErrors = [...validationResult];
+                        resolve(this.convertToValidationErrors(ajvErrors));
                     }
-                ).catch((error) => {
-                if (error.errors) {
-                    logger.error("An error occurred while running the validation: " + JSON.stringify(error))
-                    reject(new AppError(error.errors));
-                } else {
-                    logger.error("An error occurred while running the validation: " + JSON.stringify(error));
-                    reject(error);
-                }
-            });
+                })
+                .catch((error) => {
+                    if (error.errors) {
+                        logger.error("An error occurred while running the validation: " + JSON.stringify(error));
+                        reject(new AppError(error.errors));
+                    } else {
+                        logger.error("An error occurred while running the validation: " + JSON.stringify(error));
+                        reject(error);
+                    }
+                });
         });
     }
 
@@ -61,6 +61,7 @@ class BioValidator {
     }
 
     clearCachedSchema() {
+        logger.info("Clearing all cached schemas and removing AJV instance schemas.");
         this.ajvInstance.removeSchema();
         this.validatorCache.flushAll();
         this.referencedSchemaCache.flushAll();
@@ -101,6 +102,7 @@ class BioValidator {
 
     _validate(inputSchema, inputObject) {
         this._insertAsyncToSchemasAndDefs(inputSchema);
+        // The following is useful for when doing a deep-debugging of schema issues, but too verbose otherwise
         // logger.debug("Final schema after injection:\n" + JSON.stringify(inputSchema, null, 2));
 
         return new Promise((resolve, reject) => {
@@ -109,21 +111,21 @@ class BioValidator {
             compiledSchemaPromise.then((validate) => {
                 Promise.resolve(validate(inputObject))
                     .then((data) => {
-                            if (validate.errors) {
-                                resolve(validate.errors);
-                            } else {
-                                resolve([]);
-                            }
+                        if (validate.errors) {
+                            resolve(validate.errors);
+                        } else {
+                            resolve([]);
                         }
-                    ).catch((err) => {
-                    if (!(err instanceof Ajv.ValidationError)) {
-                        logger.error("An error occurred while running the validation. " + err);
-                        reject(new AppError("An error occurred while running the validation. " + err));
-                    } else {
-                        logger.info("Validation failed with errors: " + this.ajvInstance.errorsText(err.errors, {dataVar: inputObject.alias}));
-                        resolve(err.errors);
-                    }
-                });
+                    })
+                    .catch((err) => {
+                        if (!(err instanceof Ajv.ValidationError)) {
+                            logger.error("An error occurred while running the validation. " + err);
+                            reject(new AppError("An error occurred while running the validation. " + err));
+                        } else {
+                            logger.info("Validation failed with errors: " + this.ajvInstance.errorsText(err.errors, {dataVar: inputObject.alias}));
+                            resolve(err.errors);
+                        }
+                    });
             }).catch((err) => {
                 logger.error("Failed to compile schema: " + JSON.stringify(err));
                 reject(new AppError("Failed to compile schema: " + JSON.stringify(err)));
@@ -148,19 +150,19 @@ class BioValidator {
 
     getValidationFunction(inputSchema) {
         const schemaId = inputSchema['$id'];
-        if (this.validatorCache.has(schemaId)) {
+        if (schemaId && this.validatorCache.has(schemaId)) {
             logger.info("Returning compiled schema from cache, $id: " + schemaId);
             return Promise.resolve(this.validatorCache.get(schemaId));
-        } else {
-            const compiledSchemaPromise = this.ajvInstance.compileAsync(inputSchema);
-            if (schemaId) {
-                logger.info("Saving compiled schema in cache, $id: " + schemaId);
-                this.validatorCache.set(schemaId, compiledSchemaPromise);
-            } else {
-                logger.warn("Compiling schema with empty schema $id. Schema will not be cached.");
-            }
-            return Promise.resolve(compiledSchemaPromise);
         }
+
+        const compiledSchemaPromise = this.ajvInstance.compileAsync(inputSchema);
+        if (schemaId) {
+            logger.info("Saving compiled schema in cache, $id: " + schemaId);
+            this.validatorCache.set(schemaId, compiledSchemaPromise);
+        } else {
+            logger.warn("Compiling schema with empty schema $id. Schema will not be cached.");
+        }
+        return Promise.resolve(compiledSchemaPromise);
     }
 
     _getAjvInstance(localSchemaPath) {
@@ -173,19 +175,21 @@ class BioValidator {
         });
         
         addFormats(ajvInstance);
-        require("ajv-errors")(ajvInstance)
+        require("ajv-errors")(ajvInstance);
 
         this._addCustomKeywordValidators(ajvInstance);
         this._preCompileLocalSchemas(ajvInstance, localSchemaPath);
 
-        return ajvInstance
+        return ajvInstance;
     }
 
     _resolveReference() {
         return (uri) => {
             // skip if it's an official meta-schema
-            if (uri.startsWith("http://json-schema.org/draft") 
-                || uri.startsWith("https://json-schema.org/draft")) {
+            if (
+                uri.startsWith("http://json-schema.org/draft") ||
+                uri.startsWith("https://json-schema.org/draft")
+            ) {
                 logger.debug(`Skipping meta-schema fetch: ${uri}`);
                 return Promise.resolve({});
             }
@@ -202,9 +206,9 @@ class BioValidator {
                             this.referencedSchemaCache.set(uri, loadedSchema);
                             resolve(loadedSchema);
                         }).catch(err => {
-                        logger.error("Failed to retrieve referenced schema: " + uri + ", " + JSON.stringify(err))
-                        reject(new AppError("Failed to resolve $ref: " + uri + ", status: " + err.statusCode));
-                    });
+                            logger.error("Failed to retrieve referenced schema: " + uri + ", " + JSON.stringify(err));
+                            reject(new AppError("Failed to resolve $ref: " + uri + ", status: " + err.statusCode));
+                        });
                 });
             }
         };
@@ -214,21 +218,20 @@ class BioValidator {
         customKeywordValidators.forEach(customKeywordValidator => {
             ajvInstance = customKeywordValidator.configure(ajvInstance);
         });
-
         logger.info("Custom keywords successfully added. Number of custom keywords: " + customKeywordValidators.length);
         return ajvInstance;
     }
 
     _preCompileLocalSchemas(ajv, localSchemaPath) {
         if (localSchemaPath) {
-            logger.info("Compiling local schema from: " + localSchemaPath)
+            logger.info("Compiling local schema from: " + localSchemaPath);
             let schemaFiles = getFiles(localSchemaPath);
             for (let file of schemaFiles) {
                 let schema = readFile(file);
                 this._insertAsyncToSchemasAndDefs(schema);
                 ajv.getSchema(schema["$id"] || ajv.compile(schema)); // add to AJV cache if not already present
                 this.referencedSchemaCache.set(schema["$id"], schema);
-                logger.info("Adding compiled local schema to cache: " + schema["$id"])
+                logger.info("Adding compiled local schema to cache: " + schema["$id"]);
             }
         }
     }

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -118,7 +118,6 @@ class BioValidator {
         // logger.debug("Final schema after injection:\n" + JSON.stringify(inputSchema, null, 2));
 
         return new Promise((resolve, reject) => {
-            logger.debug(`Attempting to get compiled validation function for schema $id: ${schemaIdForLog}'}`);
             const compiledSchemaPromise = this.getValidationFunction(inputSchema);
 
             compiledSchemaPromise.then((validate) => {

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -28,8 +28,8 @@ class BioValidator {
 
     // wrapper around _validate to process output
     validate(inputSchema, inputObject) {
-        const sid = inputSchema["$id"] || "(no $id)";
-        logger.debug(`BioValidator.validate() called for initial schema $id: ${sid}`);
+        const sid = inputSchema["$id"] || "(no '$id')";
+        logger.debug(`BioValidator.validate() called for initial schema '$id': '${sid}'`);
 
         return new Promise((resolve, reject) => {
             this._validate(inputSchema, inputObject)
@@ -42,7 +42,7 @@ class BioValidator {
                     }
                 })
                 .catch((error) => {
-                    logger.error(`BioValidator.validate() caught error processing schema $id: ${sid}. Error: ${error.message || JSON.stringify(error)}`);
+                    logger.error(`BioValidator.validate() caught error processing schema '$id': '${sid}'. Error: ${error.message || JSON.stringify(error)}`);
                     if (error.errors) {
                         logger.error("AJV validation errors encountered: " + JSON.stringify(error.errors));
                         reject(new AppError(error.errors));
@@ -71,7 +71,7 @@ class BioValidator {
     // AJV requires $async keyword in schemas if they use any of async custom defined keywords.
     // We populate all schemas/defs with $async as a workaround to avoid users manually entering $async in schemas.
     _insertAsyncToSchemasAndDefs(inputSchema) {
-        const schemaIdForLog = inputSchema.$id || "[no $id at root]"; // Use for logging
+        const schemaIdForLog = inputSchema.$id || "[no '$id' at root]"; // Use for logging
         // If it's the known meta-schema ID, skip adding $async
         if (
             typeof inputSchema.$id === "string" &&
@@ -80,17 +80,17 @@ class BioValidator {
                 inputSchema.$id.startsWith("https://json-schema.org/draft")
             )
         ) {
-            logger.debug(`Skipping $async injection for official meta-schema $id: ${schemaIdForLog}`);
+            logger.debug(`Skipping "$async" injection for official meta-schema '$id': '${schemaIdForLog}'`);
             return;
         }
 
         if (!inputSchema.hasOwnProperty("$async")) {
             inputSchema["$async"] = true;
-            logger.debug(`Auto-injected "$async": true at root for schema $id: ${schemaIdForLog}`);
+            logger.debug(`Auto-injected "$async": true at root for schema '$id': '${schemaIdForLog}'`);
         } else if (inputSchema.$async === true) {
-            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' for schema $id: ${schemaIdForLog}`);
+            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' for schema '$id': '${schemaIdForLog}'`);
         } else if (inputSchema.$async === false) {
-            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' ('$async' injection will be skipped for definitions) for schema $id: ${schemaIdForLog}`);
+            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' ('$async' injection will be skipped for definitions) for schema '$id': '${schemaIdForLog}'`);
             return; // Don't inject if explicitly false
         }
 
@@ -121,14 +121,14 @@ class BioValidator {
             const compiledSchemaPromise = this.getValidationFunction(inputSchema);
 
             compiledSchemaPromise.then((validate) => {
-                logger.info(`Successfully obtained compiled function for schema $id: ${schemaIdForLog}'}. Now validating data.`);
+                logger.info(`Successfully obtained compiled function for schema '$id': '${schemaIdForLog}'.`);
                 Promise.resolve(validate(inputObject))
                     .then((data) => {
                         if (validate.errors) {
-                            logger.info(`Validation finished with errors for schema $id: ${schemaIdForLog}'}.`);
+                            logger.info(`Validation finished with errors for schema '$id': '${schemaIdForLog}'.`);
                             resolve(validate.errors);
                         } else {
-                           logger.info(`Validation finished successfully for schema $id: ${schemaIdForLog}'}.`);
+                           logger.info(`Validation finished successfully for schema '$id': '${schemaIdForLog}'.`);
                             resolve([]);
                         }
                     })
@@ -137,15 +137,16 @@ class BioValidator {
                             logger.error("An unexpected error occurred during data validation execution. " + (err.message || err));
                             reject(new AppError("An error occurred while running the validation. " + (err.message || err)));
                         } else {
-                            logger.info("Validation failed with AJV ValidationError: " + this.ajvInstance.errorsText(err.errors, {dataVar: inputObject.alias}));
+                            logger.error("Validation failed with AJV ValidationError: " + this.ajvInstance.errorsText(err.errors, {dataVar: inputObject.alias}));
                             resolve(err.errors);
                         }
                     });
              }).catch(err => {
-                 logger.error(`Failed to compile/get validation function for schema $id: ${schemaIdForLog}. Error: ${err.message || JSON.stringify(err)}`);
+                 logger.error(`Failed to compile/get validation function for schema '$id': '${schemaIdForLog}'. Error: ${err.message || JSON.stringify(err)}`);
                  if (err instanceof Ajv.MissingRefError) {
                      logger.error(
-                         `AJV MissingRefError (Failed to compile - missing $ref)': ${err.missingRef}'. ` +
+                         `AJV MissingRefError (Failed to compile)` +
+                         `. Missing '$ref': ${err.missingRef}'. ` +
                          `Base URI/Schema where error occurred: '${err.missingSchema || inputSchema.$id || "(root)"}'`
                      );
                  } else if (err instanceof AppError) {
@@ -183,17 +184,17 @@ class BioValidator {
     getValidationFunction(inputSchema) {
         const schemaId = inputSchema['$id'];
         if (schemaId && this.validatorCache.has(schemaId)) {
-            logger.info("Returning compiled schema from validator cache, $id: " + schemaId);
+            logger.info("Returning compiled schema from validator cache, '$id': " + schemaId);
             return Promise.resolve(this.validatorCache.get(schemaId));
         }
 
-        logger.debug(`Compiling schema $id: ${schemaId || '(no $id)'}. This will trigger loading of external references.`);
+        logger.debug(`Compiling schema '$id': ${schemaId || "(no '$id')"}. This will trigger loading of external references.`);
         const compiledSchemaPromise = this.ajvInstance.compileAsync(inputSchema);
         if (schemaId) {
-            logger.info("Saving compiled schema in validator cache, $id: " + schemaId);
+            logger.info("Saving compiled schema in validator cache, '$id': " + schemaId);
             this.validatorCache.set(schemaId, compiledSchemaPromise);
         } else {
-            logger.warn("Compiling schema with empty schema $id. Schema will not be cached in validator cache.");
+            logger.warn("Compiling schema with empty schema '$id'. Schema will not be cached in validator cache.");
         }
         return Promise.resolve(compiledSchemaPromise);
     }
@@ -251,7 +252,7 @@ class BioValidator {
                                  `Failed to fetch referenced schema URI: ${uri} (Status: ${status}). Error: ${err.message || err}`
                              );
                              reject(
-                                 new AppError(`Failed to resolve $ref via network/file (status: ${status}): ${uri}. Original error: ${err.message}`)
+                                 new AppError(`Failed to resolve $ref via network/DNS/file (Status: ${status}): ${uri}. Original error: ${err.message}`)
                              );
                          });
                  });

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -69,15 +69,28 @@ class BioValidator {
     // AJV requires $async keyword in schemas if they use any of async custom defined keywords.
     // We populate all schemas/defs with $async as a workaround to avoid users manually entering $async in schemas.
     _insertAsyncToSchemasAndDefs(inputSchema) {
-        // If it's the known meta-schema ID, skip
-        if (typeof inputSchema.$schema === "string") {
-            if (inputSchema.$schema.startsWith("http://json-schema.org/draft")
-                || inputSchema.$schema.startsWith("https://json-schema.org/draft")) {
-                return;
-            }
+        // If it's the known meta-schema ID, skip adding $async
+        if (
+            typeof inputSchema.$id === "string" &&
+            (
+                inputSchema.$id.startsWith("http://json-schema.org/draft") ||
+                inputSchema.$id.startsWith("https://json-schema.org/draft")
+            )
+        ) {
+            logger.debug(`Skipping $async injection for official meta-schema $id: ${inputSchema.$id || "[no $id at root]"}`);
+            return;
         }
 
-        inputSchema["$async"] = true;
+        if (!inputSchema.hasOwnProperty("$async")) {
+            inputSchema["$async"] = true;
+            logger.debug(`Auto-injected "$async": true at root for schema $id: ${inputSchema.$id || "[no $id at root]"}`);
+        } else if (inputSchema.$async === true) {
+            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' for schema $id: ${inputSchema.$id || "[no $id at root]"}`);
+        } else if (inputSchema.$async === false) {
+            logger.debug(`Root already has "$async": '${inputSchema["$async"]}' ('$async' injection will be skipped for definitions) for schema $id: ${inputSchema.$id || "[no $id at root]"}`);
+            return;
+        }
+
         if (inputSchema.hasOwnProperty("definitions")) {
             let defs = Object.keys(inputSchema.definitions);
             for (let x = 0; x < defs.length; x++) {
@@ -88,6 +101,7 @@ class BioValidator {
 
     _validate(inputSchema, inputObject) {
         this._insertAsyncToSchemasAndDefs(inputSchema);
+        // logger.debug("Final schema after injection:\n" + JSON.stringify(inputSchema, null, 2));
 
         return new Promise((resolve, reject) => {
             const compiledSchemaPromise = this.getValidationFunction(inputSchema);

--- a/src/core/biovalidator-core.js
+++ b/src/core/biovalidator-core.js
@@ -97,6 +97,10 @@ class BioValidator {
             for (let x = 0; x < defs.length; x++) {
                 inputSchema.definitions[defs[x]]["$async"] = true;
             }
+        } else if (inputSchema.hasOwnProperty("$defs")) { // support draft‑2019/2020 keyword ($defs)
+            for (const k of Object.keys(inputSchema.$defs)) {
+                inputSchema.$defs[k]["$async"] = true;
+            }
         }
     }
 
@@ -126,11 +130,27 @@ class BioValidator {
                             resolve(err.errors);
                         }
                     });
-            }).catch((err) => {
-                logger.error("Failed to compile schema: " + JSON.stringify(err));
-                reject(new AppError("Failed to compile schema: " + JSON.stringify(err)));
+                }).catch(err => {
+                    if (err instanceof Ajv.MissingRefError) {
+                        logger.error(
+                            `Failed to compile - missing $ref '${err.missingRef}' ` +
+                            `in schema '${err.missingSchema || inputSchema.$id || "(root)"}'`
+                        );
+                    } else if (err instanceof AppError) {
+                        logger.error(err.error || err.message || JSON.stringify(err));
+                    } else if (err.errors && err.errors.length) {
+                        logger.error(
+                            "Schema compile errors:\n" +
+                            err.errors
+                               .map(e => `  ✖ ${e.message} @ ${e.schemaPath}`)
+                               .join("\n")
+                        );
+                    } else {
+                        logger.error("Unexpected compile failure:\t" + (err.stack || err));
+                    }
+                    reject(new AppError("Failed to compile schema. See server log for details."));
+                });
             });
-        });
     }
 
     convertToValidationErrors(ajvErrorObjects) {
@@ -206,8 +226,18 @@ class BioValidator {
                             this.referencedSchemaCache.set(uri, loadedSchema);
                             resolve(loadedSchema);
                         }).catch(err => {
-                            logger.error("Failed to retrieve referenced schema: " + uri + ", " + JSON.stringify(err));
-                            reject(new AppError("Failed to resolve $ref: " + uri + ", status: " + err.statusCode));
+                            // If Axios reached the server but got an HTTP error (e.g., 404, 500...), 
+                            //      err.response exists, and we keep the numeric status
+                            // If the request never left the host (e.g., bad domain), err.response is
+                            //      undefined (?), and we label it "nerwork/DNS"
+                            const status =
+                                err.response ? err.response.status : "network/DNS";
+                            logger.error(
+                                `Failed to fetch referenced schema (status: ${status}): ${uri}`
+                            );
+                            reject(
+                                new AppError(`Failed to resolve $ref (status: ${status}): ${uri}`)
+                            );
                         });
                 });
             }

--- a/test/asyncCustomKeywords.test.js
+++ b/test/asyncCustomKeywords.test.js
@@ -1,0 +1,105 @@
+const fs = require("fs");
+const path = require("path");
+const BioValidator = require("../src/core/biovalidator-core");
+
+/**
+ * In this test, we check how Biovalidator behaves when JSON Schemas
+ * contain '$async' at the root (true, missing, false) in conjunction
+ * with or without a custom keyword. The only scenario that should 
+ * fail is when '$async' is explicitly false AND a custom keyword is in use.
+ */
+
+describe("asyncCustomKeywords test suite", () => {
+  let biovalidator;
+
+  beforeEach(() => {
+    // Recreate a brand-new instance for each test. It's required so that we can re-use the same
+    // schema (graphRestriction-schema.json) while changing properties inside on the fly.
+    // Without cleaning cache, Biovalidator simply reuses the first compiled schema with that $id.
+    biovalidator = new BioValidator();
+  });
+
+  test("Scenario #1: `$async: true` + custom keyword => valid", () => {
+    const schemaPath = path.join(__dirname, "..", "examples", "schemas", "graphRestriction-schema.json");
+    const schemaOriginal = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
+  
+    // Ensure `$async` is explicitly true at the root:
+    const schema = { ...schemaOriginal, $async: true };
+  
+    // Load a valid data object that exercises the custom keyword:
+    const dataPath = path.join(__dirname, "..", "examples", "objects", "graphRestriction_pass.json");
+    const data = JSON.parse(fs.readFileSync(dataPath, "utf-8"));
+  
+    return biovalidator.validate(schema, data).then(errors => {
+      expect(errors).toBeDefined();
+      expect(errors.length).toBe(0); // must pass
+    });
+  });
+  
+  test("Scenario #2: missing `$async` + custom keyword => valid", () => {
+    const schemaPath = path.join(__dirname, "..", "examples", "schemas", "graphRestriction-schema.json");
+    const schemaOriginal = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
+  
+    // Remove any `$async` at root if it exists:
+    const schema = { ...schemaOriginal };
+    delete schema.$async;
+  
+    const dataPath = path.join(__dirname, "..", "examples", "objects", "graphRestriction_pass.json");
+    const data = JSON.parse(fs.readFileSync(dataPath, "utf-8"));
+  
+    return biovalidator.validate(schema, data).then(errors => {
+      expect(errors).toBeDefined();
+      expect(errors.length).toBe(0); // must pass after injection
+    });
+  });
+  
+  
+  test("Scenario #3: `$async: false` + NO custom keyword => valid", () => {
+    // We reuse a simple schema that doesn't rely on custom keywords (e.g. test-schema.json).
+    const schemaPath = path.join(__dirname, "..", "examples", "schemas", "test-schema.json");
+    const schemaOriginal = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
+  
+    // Force `$async` = false
+    const schema = { ...schemaOriginal, $async: false };
+  
+    // Provide some minimal data that meets the schema
+    const data = {
+      name: "No custom keywords scenario",
+      characteristics: {
+        species: [
+          {
+            text: "Homo sapiens" // Enough to satisfy 'nonEmptyString'
+          }
+        ]
+      }
+    };
+  
+    return biovalidator.validate(schema, data).then(errors => {
+      expect(errors).toBeDefined();
+      expect(errors.length).toBe(0); // must pass
+    });
+  });
+  
+  test("Scenario #4: `$async: false` + custom keyword => should fail", () => {
+    const schemaPath = path.join(__dirname, "..", "examples", "schemas", "graphRestriction-schema.json");
+    const schemaOriginal = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
+    const schema = { ...schemaOriginal, $async: false };
+  
+    const dataPath = path.join(__dirname, "..", "examples", "objects", "graphRestriction_pass.json");
+    const data = JSON.parse(fs.readFileSync(dataPath, "utf-8"));
+  
+    return biovalidator.validate(schema, data).then(
+      // success callback:
+      () => {
+        // If we get here, that means no compile error occurred, which is unexpected.
+        // So forcibly fail:
+        fail("Expected compile/validation error ('$async' was 'false' but used AJV's async features), but validation passed unexpectedly.");
+      },
+      // failure callback:
+      (err) => {
+        expect(err).toBeDefined();
+        expect(err.error).toContain("Failed to compile schema");
+      }
+    );
+  });  
+});

--- a/test/draftsCompatibility.test.js
+++ b/test/draftsCompatibility.test.js
@@ -1,0 +1,116 @@
+const fs = require("fs");
+const path = require("path");
+const BioValidator = require("../src/core/biovalidator-core");
+const biovalidator = new BioValidator();
+
+/**
+ * In this test, we manually load "examples/both" JSON files, each of which
+ * contains an embedded "schema" and "data" property. There's one test for each draft:
+ * 06, 07, 2019, and 2020, using both a "valid" and "invalid" example.
+ */
+
+test("Draft 06 - valid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-06SchemaDraft-valid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    // For a valid file, we expect 0 errors ('[]')
+    expect(errors).toBeDefined();
+    expect(errors.length).toBe(0);
+  });
+});
+
+test("Draft 06 - invalid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-06SchemaDraft-invalid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    // For an invalid file, we expect at least 1 error ('["..."]')
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+test("Draft 07 - valid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-07SchemaDraft-valid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    expect(errors).toBeDefined();
+    expect(errors.length).toBe(0);
+  });
+});
+
+test("Draft 07 - invalid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-07SchemaDraft-invalid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+test("Draft 2019 - valid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-2019SchemaDraft-valid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    expect(errors).toBeDefined();
+    expect(errors.length).toBe(0);
+  });
+});
+
+test("Draft 2019 - invalid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-2019SchemaDraft-invalid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+test("Draft 2020 - valid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-2020SchemaDraft-valid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    expect(errors).toBeDefined();
+    expect(errors.length).toBe(0);
+  });
+});
+
+test("Draft 2020 - invalid", () => {
+  const fileContent = fs.readFileSync(
+    path.join(__dirname, "..", "examples", "both", "test-2020SchemaDraft-invalid.json"),
+    "utf-8"
+  );
+  const { schema, data } = JSON.parse(fileContent);
+
+  return biovalidator.validate(schema, data).then((errors) => {
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Issue / Ticket Reference
https://github.com/elixir-europe/biovalidator/issues/81

## Overall Changes
- Modified how ``Ajv`` instances are created, dropping the bespoke ``Ajv2019`` and unused ``Ajv2020``. 
- Removed the hardcoded block stopping draft 2020 from working.
- Added skipping snippets for the ``$async`` not to be injected in loops for official JSON Schema drafts when resolving references.
- Updated AJV requirement to above 8.12.0
- Added ``examples/both/`` with both ``data`` and ``schema`` together in a JSON, to test the deployed server through requests. Each draft from 06 to 2020 has a ``valid`` and ``invalid`` file.

## Future To-Dos
- [x] Add proper tests trhough npm test for each draft that Biovalidator is compatible with

## Testing
````
$ npm test

> biovalidator@2.2.2 test
> jest

...

Test Suites: 13 passed, 13 total
Tests:       36 passed, 36 total
Snapshots:   0 total
Time:        23.113 s
Ran all test suites.
````

And a more manual testing to check that drafts are accepted and validation works as intended:
````
$ for file in $(ls ./*-valid*); do curl --data @$file -H "Content-Type: application/json" -X POST "http://localhost:3020/validate" ; echo $file ; done
[]./test-06SchemaDraft-valid.json
[]./test-07SchemaDraft-valid.json
[]./test-2019SchemaDraft-valid.json
[]./test-2020SchemaDraft-valid.json

$ for file in $(ls ./*-invalid*); do curl --data @$file -H "Content-Type: application/json" -X POST "http://localhost:3020/validate" ; echo $file ; done
[{"dataPath":"/foo","errors":["must be equal to constant"]}]./test-06SchemaDraft-invalid.json
[{"dataPath":"/bar","errors":["must have required property 'bar'"]},{"dataPath":"","errors":["must match \"then\" schema"]}]./test-07SchemaDraft-invalid.json
[{"dataPath":"/foo","errors":["must be string"]}]./test-2019SchemaDraft-invalid.json
[{"dataPath":"/foo","errors":["must be string"]}]./test-2020SchemaDraft-invalid.json
````